### PR TITLE
fixing Siafu startup problem on Mac OS X

### DIFF
--- a/Siafu/src/de/nec/nle/siafu/graphics/GUI.java
+++ b/Siafu/src/de/nec/nle/siafu/graphics/GUI.java
@@ -430,6 +430,7 @@ public class GUI implements Runnable {
 		reportSimulationDataChange(simulationPath);
 		// Force the first redraw
 		simulationDataChanged = true;
+		display = new Display();
 	}
 
 	/**
@@ -587,13 +588,15 @@ public class GUI implements Runnable {
 	 */
 	public void run() {
 		System.out.println("Starting Siafu...");
-		display = new Display();
+		display.syncExec(new Runnable() {
+			public void run() {
+				createShell();
+				switchToStandByMode();
 
-		createShell();
-		switchToStandByMode();
-
-		display.timerExec(refreshSpeed, refreshSimulationRunnable);
-		swtLoop();
+				display.timerExec(refreshSpeed, refreshSimulationRunnable);
+				swtLoop();
+			}
+		});
 		System.out.println("Siafu ended");
 	}
 


### PR DESCRIPTION
fixes #2
move Display initialization in GUI constructor
run SWT code in display.syncExec()

tested and works in Mac OS X ML 10.8.1 and Windows 7 x64
